### PR TITLE
Implement middleware and new way of initialization

### DIFF
--- a/inertia/middleware.go
+++ b/inertia/middleware.go
@@ -1,0 +1,47 @@
+package inertia
+
+import (
+	"context"
+	"net/http"
+)
+
+type MiddlewareFunc func(http.Handler) http.Handler
+
+func Middleware(inertia *Inertia) MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), inertiaCtxKey, inertia)
+			req := r.WithContext(ctx)
+
+			if r.Header.Get("X-Inertia") == "" {
+				next.ServeHTTP(w, req)
+				return
+			}
+
+			if r.Method == "GET" && r.Header.Get("X-Inertia-Version") != inertia.GetVersion() {
+				w.Header().Add("X-Inertia-Location", r.URL.String())
+				w.WriteHeader(http.StatusConflict)
+				return
+			}
+
+			rw := &responseWriter{w, req}
+			next.ServeHTTP(rw, req)
+		})
+	}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	req *http.Request
+}
+
+func (rw *responseWriter) WriteHeader(status int) {
+	if status == http.StatusFound {
+		switch rw.req.Method {
+		case "PUT", "PATCH", "DELETE":
+			rw.WriteHeader(http.StatusSeeOther)
+			return
+		}
+	}
+	rw.WriteHeader(status)
+}

--- a/inertia/middleware.go
+++ b/inertia/middleware.go
@@ -18,7 +18,10 @@ func Middleware(inertia *Inertia) MiddlewareFunc {
 				return
 			}
 
-			if r.Method == "GET" && r.Header.Get("X-Inertia-Version") != inertia.GetVersion() {
+			// In case the assets version in the X-Inertia-Version header does not match the current version
+			// of assets we have on the server, return a 409 response which will cause Inertia to make a new
+			// hard visit.
+			if r.Method == "GET" && r.Header.Get("X-Inertia-Version") != inertia.getVersion() {
 				w.Header().Add("X-Inertia-Location", r.URL.String())
 				w.WriteHeader(http.StatusConflict)
 				return


### PR DESCRIPTION
- Initialization through a middleware layer: 
	- The Inertia object is stored in the request context by the middleware. In the Render method, this Inertia object is fetched from the context.
- Implement the actual middleware logic: 
	- If the X-Inertia-Version header does not match, return a 409 status code
	- If the handler returns a 302 redirect for a PUT, PATCH or DELETE request, change this to a 303 redirect (c.f. https://inertiajs.com/redirects#303-response-code).
﻿
